### PR TITLE
Removed jxl feature

### DIFF
--- a/src/PIL/_jxl.pyi
+++ b/src/PIL/_jxl.pyi
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -125,7 +125,6 @@ features = {
     "webp_anim": ("PIL._webp", "HAVE_WEBPANIM", None),
     "webp_mux": ("PIL._webp", "HAVE_WEBPMUX", None),
     "transp_webp": ("PIL._webp", "HAVE_TRANSPARENCY", None),
-    "jxl": ("PIL._jxl", "HAVE_JXL", None),
     "raqm": ("PIL._imagingft", "HAVE_RAQM", "raqm_version"),
     "fribidi": ("PIL._imagingft", "HAVE_FRIBIDI", "fribidi_version"),
     "harfbuzz": ("PIL._imagingft", "HAVE_HARFBUZZ", "harfbuzz_version"),


### PR DESCRIPTION
You may have noticed that most of the CI jobs are failing at https://github.com/python-pillow/Pillow/pull/7848

- Lint is failing because mypy can't find _jxl - https://github.com/python-pillow/Pillow/actions/runs/8121910543/job/22200964297?pr=7848#step:8:17. I've added a stub file here to fix that.
- In many jobs, testing for the "jxl" feature fails - https://github.com/python-pillow/Pillow/actions/runs/8121910544/job/22201592738?pr=7848#step:10:1300. This is because you've written `"jxl": ("PIL._jxl", "HAVE_JXL", None)`, but not defined "HAVE_JXL" in _jxl. I don't think it needs to be a "feature", so I've removed it here.
- macOS Python 3.8 and 3.9 fail to build - https://github.com/python-pillow/Pillow/actions/runs/8121910544/job/22201593322?pr=7848#step:9:256. I imagine you might have thoughts on that though.