### PR TITLE
Jxl support2

### DIFF
--- a/Tests/test_file_jxl.py
+++ b/Tests/test_file_jxl.py
@@ -45,7 +45,10 @@ class TestFileJpegXl:
 
     def test_version(self) -> None:
         _jpegxl.JpegXlDecoderVersion()
-        assert re.search(r"\d+\.\d+\.\d+$", features.version_module("jpegxl"))
+        version_mode = features.version_module("jpegxl")
+        assert version_mode is not None
+        if version_mode:
+            assert re.search(r"\d+\.\d+\.\d+$", version_mode)
 
     def test_read_rgb(self) -> None:
         """

--- a/src/PIL/JpegXlImagePlugin.py
+++ b/src/PIL/JpegXlImagePlugin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import struct
 from io import BytesIO
+from typing import Any
 
 from . import Image, ImageFile
 
@@ -81,13 +82,10 @@ class JpegXlImageFile(ImageFile.ImageFile):
         exif_start_offset = struct.unpack(">I", exif[:4])[0]
         return exif[exif_start_offset + 4 :]
 
-    def _getexif(self) -> dict[str, str] | None:
+    def _getexif(self) -> dict[int, Any] | None:
         if "exif" not in self.info:
             return None
         return self.getexif()._get_merged_dict()
-
-    def getxmp(self) -> dict[str, str]:
-        return self._getxmp(self.info["xmp"]) if "xmp" in self.info else {}
 
     def _get_next(self) -> tuple[bytes, float, float, bool]:
 

--- a/src/PIL/_jpegxl.pyi
+++ b/src/PIL/_jpegxl.pyi
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 def __getattr__(name: str) -> Any: ...


### PR DESCRIPTION
Fixes failed workflows

Changes proposed in this pull request:

 * remove `from __future__ import annotations` from `src/PIL/_jpegxl.pyi`
 * unwrap optional jpegxl version_module in `Tests/test_file_jxl.py`
